### PR TITLE
fix(ci): add missing input

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -8,6 +8,11 @@ on:
       - how-to/content_sharing_configuration_snap
   workflow_dispatch:
   workflow_call:
+    inputs:
+       branch-name:
+         required: false
+         type: string
+         default: ''
 
 jobs:
 


### PR DESCRIPTION
Monthly has been failing: https://github.com/canonical/snap_configuration/actions/runs/12866039173/job/35876005695

It turns out this branch was not taking any branch input.

The branch input is necessary from the monthly since we want to checkout a specific branch.

Tested here: https://github.com/canonical/snap_configuration/actions/runs/12869695334