### PR TITLE
fix(monthly): provide branch name for how-to/content-sharing branch

### DIFF
--- a/.github/workflows/monthly.yaml
+++ b/.github/workflows/monthly.yaml
@@ -15,6 +15,8 @@ jobs:
       branch-name: "howto/pull_configuration_from_a_server"
   howto-content-configuration-snap:
     uses: canonical/snap_configuration/.github/workflows/snap.yaml@how-to/content_sharing_configuration_snap
+    with:
+      branch-name: "how-to/content_sharing_configuration_snap"
   howto-overwritable-configuration-snap:
     uses: canonical/snap_configuration/.github/workflows/snap.yaml@how-to/overwritable_configuration
     with:


### PR DESCRIPTION
To make https://github.com/canonical/snap_configuration/pull/33 work.

We specify the branch name in the monthly now that we take the input.