### PR TITLE
fix(keep_alive): rename job

### DIFF
--- a/.github/workflows/keep_alive.yaml
+++ b/.github/workflows/keep_alive.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  keep-alive:
+  keep_alive:
     uses: canonical/robotics-actions-workflows/.github/workflows/keepalive.yaml@main
     with:
       workflow_files: "./monthly.yaml"


### PR DESCRIPTION
I noticed that the keep alive workflow stopped working: https://github.com/canonical/snap_configuration/actions/runs/12858333766

I couldn't find out why. So I compared with ros2-nav2-snap, turtlebot3c-snap and ros-snapd.

I found out the only difference is in the job name.

Here is the result: https://github.com/canonical/snap_configuration/actions/runs/12869980009